### PR TITLE
Simplify is_http by returning the condition directly

### DIFF
--- a/core/src/url.rs
+++ b/core/src/url.rs
@@ -43,10 +43,7 @@ impl Url {
     }
 
     fn is_http(&self) -> bool {
-        if self.url.contains("http://") {
-            return true;
-        }
-        false
+        self.url.contains("http://")
     }
 
     fn extract_host(&self) -> String {


### PR DESCRIPTION
This PR simplifies the `is_http` method in `Url` by directly returning the result of the condition instead of using an `if` statement. This makes the code more concise without changing its behavior.