### PR TITLE
Refactor HTML tokenizer to unconditionally set reconsume in two states

### DIFF
--- a/core/src/renderer/html/token.rs
+++ b/core/src/renderer/html/token.rs
@@ -302,13 +302,13 @@ impl Iterator for HtmlTokenizer {
                 }
                 // https://html.spec.whatwg.org/multipage/parsing.html#before-attribute-name-state
                 State::BeforeAttributeName => {
+                    self.reconsume = true;
+
                     if c == '/' || c == '>' || self.is_eof() {
-                        self.reconsume = true;
                         self.state = State::AfterAttributeName;
                         continue;
                     }
 
-                    self.reconsume = true;
                     self.state = State::AttributeName;
                     self.start_new_attribute();
                 }

--- a/core/src/renderer/html/token.rs
+++ b/core/src/renderer/html/token.rs
@@ -491,14 +491,14 @@ impl Iterator for HtmlTokenizer {
                 }
                 // https://html.spec.whatwg.org/multipage/parsing.html#script-data-end-tag-open-state
                 State::ScriptDataEndTagOpen => {
+                    self.reconsume = true;
+
                     if c.is_ascii_alphabetic() {
-                        self.reconsume = true;
                         self.state = State::ScriptDataEndTagName;
                         self.create_tag(false);
                         continue;
                     }
 
-                    self.reconsume = true;
                     self.state = State::ScriptData;
                     // TODO: emit '<' and '/'
                     // "Emit a U+003C LESS-THAN SIGN character token and a U+002F SOLIDUS character


### PR DESCRIPTION
This pull request refactors the HtmlTokenizer to always set self.reconsume = true at the beginning of two states:

* BeforeAttributeName
* ScriptDataEndTagOpen

In both cases, the flag was previously set conditionally in multiple branches, but always ended up being set regardless of the input. 

This change does not affect behavior and serves purely as a cleanup aligned with the structure of the HTML parsing algorithm.