### PR TITLE
Add test for HtmlTokenizer::next() in State::ScriptData

### DIFF
--- a/core/src/renderer/html/token.rs
+++ b/core/src/renderer/html/token.rs
@@ -662,4 +662,32 @@ mod tests {
             assert_eq!(Some(e), tokenizer.next());
         }
     }
+
+    #[test]
+    fn test_script_context() {
+        let html = "<script>js code;</script>".to_string();
+        let mut tokenizer = HtmlTokenizer::new(html);
+        assert_eq!(Some(HtmlToken::StartTag {
+                tag: "script".to_string(),
+                self_closing: false,
+                attributes: Vec::new(),
+            }), tokenizer.next());
+        tokenizer.switch_context(State::ScriptData);
+        let expected = [
+            HtmlToken::Char('j'),
+            HtmlToken::Char('s'),
+            HtmlToken::Char(' '),
+            HtmlToken::Char('c'),
+            HtmlToken::Char('o'),
+            HtmlToken::Char('d'),
+            HtmlToken::Char('e'),
+            HtmlToken::Char(';'),
+            HtmlToken::EndTag {
+                tag: "script".to_string(),
+            },
+        ];
+        for e in expected {
+            assert_eq!(Some(e), tokenizer.next());
+        }
+    }
 }


### PR DESCRIPTION
This PR adds a test case for `HtmlTokenizer::next()` when the tokenizer is operating in the `State::ScriptData` context.