### PR TITLE
Remove redundant clone in `node_kind` method

### DIFF
--- a/core/src/renderer/layout/layout_object.rs
+++ b/core/src/renderer/layout/layout_object.rs
@@ -183,7 +183,7 @@ impl LayoutObject {
     }
 
     pub fn node_kind(&self) -> NodeKind {
-        self.node.borrow().kind().clone()
+        self.node.borrow().kind()
     }
 
     pub fn set_first_child(&mut self, first_child: Option<Rc<RefCell<LayoutObject>>>) {


### PR DESCRIPTION
The `node_kind` method was calling `.clone()` on the result of `Node::kind()`, but `Node::kind()` already returns a cloned `NodeKind`. This PR removes the redundant clone so that the method no longer performs it twice.